### PR TITLE
replace set-output with environment files due to deprecation

### DIFF
--- a/.github/workflows/should_run.yaml
+++ b/.github/workflows/should_run.yaml
@@ -32,4 +32,4 @@ jobs:
         continue-on-error: true
         name: Only run deploy on scheduled action if last commit was by dependabot[bot] and dependabot[bot] has made a commit in the last 24hrs
         if: ((github.event_name == 'schedule' && env.LAST_AUTHOR == 'dependabot[bot]' && env.LAST_24_DPB == 'true') || (github.event_name == 'push'))
-        run: echo "::set-output name=should_run::true"
+        run: echo "should_run=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/